### PR TITLE
Add route metadata to SwapInfo

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,4 +14,5 @@ export const EMPTY_SWAPINFO: SwapInfo = {
     returnAmountConsideringFees: Zero,
     returnAmountFromSwaps: Zero,
     marketSp: Zero.toString(),
+    routes: [],
 };

--- a/src/router/sorClass.ts
+++ b/src/router/sorClass.ts
@@ -260,6 +260,7 @@ export const formatSwaps = (
                     tokenIn: path.swaps[i].tokenIn,
                     tokenOut: path.swaps[i].tokenOut,
                     swapAmount: amounts[i].toString(),
+                    swapAmountOut: amounts[i + 1].toString(),
                     tokenInDecimals: path.poolPairData[i].decimalsIn,
                     tokenOutDecimals: path.poolPairData[i].decimalsOut,
                 };
@@ -281,6 +282,7 @@ export const formatSwaps = (
                     tokenIn: path.swaps[n - 1 - i].tokenIn,
                     tokenOut: path.swaps[n - 1 - i].tokenOut,
                     swapAmount: amounts[1].toString(),
+                    swapAmountOut: amounts[0].toString(),
                     tokenInDecimals: path.poolPairData[n - 1 - i].decimalsIn,
                     tokenOutDecimals: path.poolPairData[n - 1 - i].decimalsOut,
                 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface Swap {
     tokenIn: string;
     tokenOut: string;
     swapAmount?: string;
+    swapAmountOut?: string;
     limitReturnAmount?: string;
     maxPrice?: string;
     tokenInDecimals: number;
@@ -129,6 +130,25 @@ export interface SwapInfo {
     tokenOut: string;
     tokenOutFromSwaps?: string; // Used with stETH/wstETH
     marketSp: string;
+    routes: SwapInfoRoute[];
+}
+
+export interface SwapInfoRoute {
+    tokenIn: string;
+    tokenInAmount: string;
+    tokenOut: string;
+    tokenOutAmount: string;
+    share: number;
+    //hops in this route, properly ordered
+    hops: SwapInfoRouteHop[];
+}
+
+export interface SwapInfoRouteHop {
+    tokenIn: string;
+    tokenInAmount: string;
+    tokenOut: string;
+    tokenOutAmount: string;
+    poolId: string;
 }
 
 export interface PoolDictionary {

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -1351,6 +1351,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: sorConfigEth.weth,
                 tokenOut: BAL.address,
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1417,6 +1418,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: sorConfigEth.weth,
                 tokenOut: BAL.address,
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1483,6 +1485,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: BAL.address,
                 tokenOut: sorConfigEth.weth,
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1549,6 +1552,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: BAL.address,
                 tokenOut: sorConfigEth.weth,
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1615,6 +1619,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: Lido.wstETH[chainId],
                 tokenOut: tokenOut,
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1683,6 +1688,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: Lido.wstETH[chainId],
                 tokenOut: tokenOut,
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1751,6 +1757,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: tokenIn,
                 tokenOut: Lido.wstETH[chainId],
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1822,6 +1829,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: tokenIn,
                 tokenOut: Lido.wstETH[chainId],
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(
@@ -1894,6 +1902,7 @@ describe(`Tests for Helpers.`, () => {
                 tokenIn: Lido.wstETH[chainId],
                 tokenOut: sorConfigEth.weth,
                 marketSp: Zero.toString(),
+                routes: [],
             };
 
             const wrappedInfo = await getWrappedInfo(


### PR DESCRIPTION
Tried this one a while back, but think its still relevant! :)

Add an expansion of the route data to the `SwapInfo`. With the expectation of many more boosted paths, the current model lacks metadata to nicely visualize the path, as seen in the screenshot of the current boosted pool routes on app.balancer.fi.

We extend the `Swap` interface to include the `swapAmountOut`, which provides all necessary data to build the `SwapInfoRoute` array  at the same moment we format the swaps. We use this model to show the route visual on beets.fi (seen below).

The initial feedback from Tom was that the `SwapInfo` object is becoming bloated, which is a fair assessment, but I believe this data is valuable enough to justify it.

![Screenshot 2022-09-13 at 08 25 59](https://user-images.githubusercontent.com/91405705/189826208-1b16912f-0a8e-4996-8421-6043fd2f9396.png)

![Screenshot 2022-09-13 at 08 25 21](https://user-images.githubusercontent.com/91405705/189825887-24f92eff-c338-4eb6-afa0-73f1702d2253.png)


