### PR TITLE
[DRAFT] Path estimations using queryBatchSwap

### DIFF
--- a/src/batchswapQuery.ts
+++ b/src/batchswapQuery.ts
@@ -1,0 +1,296 @@
+import {
+    FundManagement,
+    NewPath,
+    Swap,
+    SwapInfo,
+    SwapTypes,
+    SwapV2,
+} from './types';
+import { BigNumber } from '@ethersproject/bignumber';
+import { AddressZero, MaxUint256, Zero } from '@ethersproject/constants';
+import { Provider } from '@ethersproject/providers';
+import { Multicaller } from '../test/lib/multicaller';
+import vaultAbi from './abi/Vault.json';
+import { uniq } from 'lodash';
+
+interface BatchSwapQueryData {
+    swapType: SwapTypes;
+    swaps: SwapV2[];
+    assets: string[];
+}
+
+export class BatchswapQuery {
+    constructor(
+        private readonly vaultAddress: string,
+        private readonly multicallAddress: string,
+        private readonly provider: Provider
+    ) {}
+
+    public async getBestPaths({
+        paths,
+        swapType,
+        swapAmount,
+        tokenIn,
+        tokenOut,
+        costOutputToken,
+    }: {
+        // we're only concerned with the swaps
+        paths: Pick<NewPath, 'swaps'>[];
+        swapAmount: BigNumber;
+        swapType: SwapTypes;
+        tokenIn: string;
+        tokenOut: string;
+        costOutputToken: BigNumber;
+    }): Promise<SwapInfo> {
+        const isExactIn = swapType === SwapTypes.SwapExactIn;
+
+        //create sampling queries for 100, 75/25, 50/50, 25/75 across the two most liquid paths
+        const queries = this.getSamplingQueriesForPaths({
+            paths,
+            swapType,
+            swapAmount,
+        });
+
+        //use multicall to query all batchswaps in a single request
+        const queryResponse = await this.queryBatchSwaps({ queries });
+
+        const { bestResultIdx, total, totalConsideringFees } =
+            this.getBestQueryIndexAndTotals({
+                isExactIn,
+                tokenIn,
+                tokenOut,
+                queries,
+                queryResponse,
+                costOutputToken,
+            });
+
+        return {
+            swaps: queries[bestResultIdx].swaps,
+            tokenAddresses: queries[bestResultIdx].assets,
+            swapAmount,
+            swapAmountForSwaps: swapAmount,
+            returnAmount: total,
+            returnAmountFromSwaps: total,
+            returnAmountConsideringFees: totalConsideringFees,
+            tokenIn,
+            tokenOut,
+            //TODO: determine the best strategy here
+            marketSp: '0',
+        };
+    }
+
+    private getSamplingQueriesForPaths({
+        paths,
+        swapType,
+        swapAmount,
+    }: {
+        paths: Pick<NewPath, 'swaps'>[];
+        swapAmount: BigNumber;
+        swapType: SwapTypes;
+    }): BatchSwapQueryData[] {
+        const queries: BatchSwapQueryData[] = [
+            // 100% to the most liquid path
+            this.formatBatchSwapQueryData({
+                swaps: this.setAmountForPathSwaps({
+                    swaps: paths[0].swaps,
+                    swapType,
+                    swapAmount: swapAmount.toString(),
+                }),
+                swapType,
+            }),
+        ];
+
+        if (paths.length > 1) {
+            queries.push(
+                this.formatPathsWithSplit({
+                    swapAmount,
+                    swapType,
+                    paths: [
+                        { ...paths[0], percent: 75 },
+                        { ...paths[1], percent: 25 },
+                    ],
+                })
+            );
+
+            queries.push(
+                this.formatPathsWithSplit({
+                    swapAmount,
+                    swapType,
+                    paths: [
+                        { ...paths[0], percent: 50 },
+                        { ...paths[1], percent: 50 },
+                    ],
+                })
+            );
+
+            queries.push(
+                this.formatPathsWithSplit({
+                    swapAmount,
+                    swapType,
+                    paths: [
+                        { ...paths[0], percent: 25 },
+                        { ...paths[1], percent: 75 },
+                    ],
+                })
+            );
+        }
+
+        return queries;
+    }
+
+    private getBestQueryIndexAndTotals({
+        isExactIn,
+        tokenIn,
+        tokenOut,
+        queries,
+        queryResponse,
+        costOutputToken,
+    }: {
+        isExactIn: boolean;
+        tokenIn: string;
+        tokenOut: string;
+        queries: BatchSwapQueryData[];
+        queryResponse: BigNumber[][];
+        costOutputToken: BigNumber;
+    }): {
+        bestResultIdx: number;
+        total: BigNumber;
+        totalConsideringFees: BigNumber;
+    } {
+        const assetOfInterest = isExactIn ? tokenOut : tokenIn;
+        let total = isExactIn ? Zero : MaxUint256;
+        let totalConsideringFees = isExactIn ? Zero : MaxUint256;
+        let bestResultIdx = -1;
+
+        for (let i = 0; i < queries.length; i++) {
+            const assetIdx = queries[i].assets.indexOf(assetOfInterest);
+            const queryTotal = isExactIn
+                ? queryResponse[i][assetIdx].abs()
+                : queryResponse[i][assetIdx];
+            const gasFees = costOutputToken.mul(queries[i].swaps.length);
+            const queryTotalConsideringFees = isExactIn
+                ? queryTotal.sub(gasFees)
+                : queryTotal.add(gasFees);
+
+            if (
+                (isExactIn &&
+                    totalConsideringFees.lt(queryTotalConsideringFees)) ||
+                (!isExactIn && total.gt(queryTotalConsideringFees))
+            ) {
+                total = queryTotal;
+                totalConsideringFees = queryTotalConsideringFees;
+                bestResultIdx = i;
+            }
+        }
+
+        return { bestResultIdx, total, totalConsideringFees };
+    }
+
+    private formatPathsWithSplit({
+        swapType,
+        swapAmount,
+        paths,
+    }: {
+        swapType: SwapTypes;
+        swapAmount: BigNumber;
+        paths: (Pick<NewPath, 'swaps'> & { percent: number })[];
+    }): BatchSwapQueryData {
+        //TODO: might be rounding error where we need to add 1 to one amount?
+        return this.formatBatchSwapQueryData({
+            swaps: paths
+                .map((path) =>
+                    this.setAmountForPathSwaps({
+                        swaps: path.swaps,
+                        swapType,
+                        swapAmount: swapAmount
+                            .mul(path.percent)
+                            .div(100)
+                            .toString(),
+                    })
+                )
+                .flat(),
+            swapType,
+        });
+    }
+
+    private formatBatchSwapQueryData({
+        swaps,
+        swapType,
+    }: {
+        swaps: Swap[];
+        swapType: SwapTypes;
+    }): BatchSwapQueryData {
+        const assets = uniq([
+            ...swaps.map((swap) => swap.tokenIn),
+            ...swaps.map((swap) => swap.tokenOut),
+        ]);
+
+        return {
+            swapType,
+            assets,
+            swaps: swaps.map((swap) => {
+                return {
+                    poolId: swap.pool,
+                    assetInIndex: assets.indexOf(swap.tokenIn),
+                    assetOutIndex: assets.indexOf(swap.tokenOut),
+                    amount: swap.swapAmount || '0',
+                    userData: '0x',
+                };
+            }),
+        };
+    }
+
+    private setAmountForPathSwaps({
+        swaps,
+        swapType,
+        swapAmount,
+    }: {
+        swaps: Swap[];
+        swapType: SwapTypes;
+        swapAmount: string;
+    }): Swap[] {
+        const isExactIn = swapType === SwapTypes.SwapExactIn;
+        const formattedSwaps = !isExactIn ? [...swaps].reverse() : swaps;
+
+        return formattedSwaps.map((swap, index) => {
+            return {
+                ...swap,
+                swapAmount: index === 0 ? swapAmount : '0',
+            };
+        });
+    }
+
+    private async queryBatchSwaps({
+        queries,
+    }: {
+        queries: BatchSwapQueryData[];
+    }): Promise<BigNumber[][]> {
+        const multicaller = new Multicaller(
+            this.multicallAddress,
+            this.provider,
+            vaultAbi
+        );
+
+        const funds: FundManagement = {
+            sender: AddressZero,
+            recipient: AddressZero,
+            fromInternalBalance: false,
+            toInternalBalance: false,
+        };
+
+        for (let i = 0; i < queries.length; i++) {
+            const { swapType, swaps, assets } = queries[i];
+
+            multicaller.call(`${i}`, this.vaultAddress, 'queryBatchSwap', [
+                swapType,
+                swaps,
+                assets,
+                funds,
+            ]);
+        }
+
+        const response = await multicaller.execute();
+
+        return Object.values(response) as BigNumber[][];
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface SorConfig {
     usdcConnectingPool?: { id: string; usdc: string };
     wETHwstETH?: { id: string; address: string };
     lbpRaisingTokens?: string[];
+    multicall: string;
 }
 
 export type NoNullableField<T> = {

--- a/test/batchswapQuery.spec.ts
+++ b/test/batchswapQuery.spec.ts
@@ -1,0 +1,138 @@
+// TS_NODE_PROJECT='tsconfig.testing.json' npx mocha -r ts-node/register test/batchswapQuery.spec.ts
+import dotenv from 'dotenv';
+dotenv.config();
+import { SwapTypes } from '../src';
+import { sorConfigEth } from './lib/constants';
+import { parseFixed } from '@ethersproject/bignumber';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { BatchswapQuery } from '../src/batchswapQuery';
+import { ADDRESSES, Network, PROVIDER_URLS } from './testScripts/constants';
+
+const COMP_WETH_POOL_ID =
+    '0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021';
+const WBTC_CHZ_LINK_COMP_POOL_ID =
+    '0x344818b9b4cfec947fe8ccbea65b3605585c2c71000100000000000000000404';
+const WETH_WBTC_POOL_ID =
+    '0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e';
+
+const tokens = ADDRESSES[Network.MAINNET];
+
+describe('batchswapQuery', () => {
+    it('selects a 75/25 split', async () => {
+        const provider = new JsonRpcProvider(PROVIDER_URLS[Network.MAINNET]);
+
+        const batchswapQuery = new BatchswapQuery(
+            sorConfigEth.vault,
+            sorConfigEth.multicall,
+            provider
+        );
+
+        const response = await batchswapQuery.getBestPaths({
+            paths: [
+                {
+                    swaps: [
+                        {
+                            pool: COMP_WETH_POOL_ID,
+                            tokenIn: tokens.COMP.address,
+                            tokenInDecimals: tokens.COMP.decimals,
+                            tokenOut: tokens.WETH.address,
+                            tokenOutDecimals: tokens.WETH.decimals,
+                        },
+                    ],
+                },
+                {
+                    swaps: [
+                        {
+                            pool: WBTC_CHZ_LINK_COMP_POOL_ID,
+                            tokenIn: tokens.COMP.address,
+                            tokenInDecimals: tokens.COMP.decimals,
+                            tokenOut: tokens.WBTC.address,
+                            tokenOutDecimals: tokens.WBTC.decimals,
+                        },
+                        {
+                            pool: WETH_WBTC_POOL_ID,
+                            tokenIn: tokens.WBTC.address,
+                            tokenInDecimals: tokens.WBTC.decimals,
+                            tokenOut: tokens.WETH.address,
+                            tokenOutDecimals: tokens.WETH.decimals,
+                        },
+                    ],
+                },
+            ],
+            swapType: SwapTypes.SwapExactIn,
+            swapAmount: parseFixed('1000', tokens.COMP.decimals),
+            tokenIn: tokens.COMP.address,
+            tokenOut: tokens.WETH.address,
+            costOutputToken: parseFixed('0.000000001', tokens.WETH.decimals),
+        });
+
+        console.log({
+            ...response,
+            returnAmount: response.returnAmount.toString(),
+            returnAmountConsideringFees:
+                response.returnAmountConsideringFees.toString(),
+            returnAmountFromSwaps: response.returnAmountFromSwaps.toString(),
+            swapAmount: response.swapAmount.toString(),
+            swapAmountForSwaps: response.swapAmountForSwaps.toString(),
+        });
+    }).timeout(10000);
+
+    it('properly formats exact out swaps', async () => {
+        const provider = new JsonRpcProvider(PROVIDER_URLS[Network.MAINNET]);
+
+        const batchswapQuery = new BatchswapQuery(
+            sorConfigEth.vault,
+            sorConfigEth.multicall,
+            provider
+        );
+
+        const response = await batchswapQuery.getBestPaths({
+            paths: [
+                {
+                    swaps: [
+                        {
+                            pool: COMP_WETH_POOL_ID,
+                            tokenIn: tokens.COMP.address,
+                            tokenInDecimals: tokens.COMP.decimals,
+                            tokenOut: tokens.WETH.address,
+                            tokenOutDecimals: tokens.WETH.decimals,
+                        },
+                    ],
+                },
+                {
+                    swaps: [
+                        {
+                            pool: WBTC_CHZ_LINK_COMP_POOL_ID,
+                            tokenIn: tokens.COMP.address,
+                            tokenInDecimals: tokens.COMP.decimals,
+                            tokenOut: tokens.WBTC.address,
+                            tokenOutDecimals: tokens.WBTC.decimals,
+                        },
+                        {
+                            pool: WETH_WBTC_POOL_ID,
+                            tokenIn: tokens.WBTC.address,
+                            tokenInDecimals: tokens.WBTC.decimals,
+                            tokenOut: tokens.WETH.address,
+                            tokenOutDecimals: tokens.WETH.decimals,
+                        },
+                    ],
+                },
+            ],
+            swapType: SwapTypes.SwapExactOut,
+            swapAmount: parseFixed('25', tokens.WETH.decimals),
+            tokenIn: tokens.COMP.address,
+            tokenOut: tokens.WETH.address,
+            costOutputToken: parseFixed('0.0001', tokens.COMP.decimals),
+        });
+
+        console.log({
+            ...response,
+            returnAmount: response.returnAmount.toString(),
+            returnAmountConsideringFees:
+                response.returnAmountConsideringFees.toString(),
+            returnAmountFromSwaps: response.returnAmountFromSwaps.toString(),
+            swapAmount: response.swapAmount.toString(),
+            swapAmountForSwaps: response.swapAmountForSwaps.toString(),
+        });
+    }).timeout(10000);
+});

--- a/test/candidatePaths.spec.ts
+++ b/test/candidatePaths.spec.ts
@@ -309,6 +309,7 @@ describe('Tests pools filtering and path processing', () => {
                 '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
                 '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
             ],
+            multicall: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
         };
         const routeProposer = new RouteProposer(config);
         const paths = routeProposer.getCandidatePathsFromDict(

--- a/test/lib/constants.ts
+++ b/test/lib/constants.ts
@@ -19,6 +19,7 @@ export const sorConfigTest: SorConfig = {
         '0x0000000000085d4780b73119b644ae5ecd22b376',
         '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     ],
+    multicall: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
 };
 
 export const sorConfigTestStaBal = {
@@ -33,24 +34,28 @@ export const sorConfigTestStaBal = {
         id: 'staBal3Id',
         address: '0x06df3b2bbb68adc8b0e302443692037ed9f91b42',
     },
+    multicall: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
 };
 
 export const sorConfigEth: SorConfig = {
     chainId: 1,
     weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-    vault: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
+    vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+    multicall: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
 };
 
 export const sorConfigKovan: SorConfig = {
     chainId: 42,
     weth: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+    multicall: '0x2cc8688C5f75E365aaEEb4ea8D6a480405A48D2A',
 };
 
 export const sorConfigFullKovan: SorConfig = {
     chainId: 42,
     weth: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+    multicall: '0x2cc8688C5f75E365aaEEb4ea8D6a480405A48D2A',
     lbpRaisingTokens: [
         '0xdfcea9088c8a88a76ff74892c1457c17dfeef9c1',
         '0xc2569dd7d0fd715b054fbf16e75b001e5c0c1115',

--- a/test/linear.spec.ts
+++ b/test/linear.spec.ts
@@ -199,6 +199,7 @@ describe('linear pool tests', () => {
                 chainId: 99,
                 weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
                 vault: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
+                multicall: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
             };
             it('getPathsUsingLinearPool return empty paths', () => {
                 const tokenIn = DAI.address;

--- a/test/testScripts/constants.ts
+++ b/test/testScripts/constants.ts
@@ -9,50 +9,6 @@ export enum Network {
     ARBITRUM = 42161,
 }
 
-export const SOR_CONFIG: Record<Network, SorConfig> = {
-    [Network.MAINNET]: {
-        chainId: Network.MAINNET, //1
-        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-        weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-        wETHwstETH: {
-            id: '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080',
-            address: '0x32296969ef14eb0c6d29669c550d4a0449130230',
-        },
-    },
-    [Network.KOVAN]: {
-        chainId: Network.KOVAN, //42
-        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-        weth: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
-        staBal3Pool: {
-            id: '0x8fd162f338b770f7e879030830cde9173367f3010000000000000000000004d8',
-            address: '0x8fd162f338b770f7e879030830cde9173367f301',
-        },
-    },
-    [Network.GOERLI]: {
-        chainId: Network.GOERLI, //5
-        vault: '0x65748E8287Ce4B9E6D83EE853431958851550311',
-        weth: '0x9A1000D492d40bfccbc03f413A48F5B6516Ec0Fd',
-    },
-    [Network.POLYGON]: {
-        chainId: Network.POLYGON, //137
-        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-        weth: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
-    },
-    [Network.ARBITRUM]: {
-        chainId: Network.ARBITRUM, //42161
-        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
-        weth: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
-    },
-};
-
-export const PROVIDER_URLS = {
-    [Network.MAINNET]: `https://mainnet.infura.io/v3/${process.env.INFURA}`,
-    [Network.GOERLI]: `https://goerli.infura.io/v3/${process.env.INFURA}`,
-    [Network.KOVAN]: `https://kovan.infura.io/v3/${process.env.INFURA}`,
-    [Network.POLYGON]: `https://polygon-mainnet.infura.io/v3/${process.env.INFURA}`,
-    [Network.ARBITRUM]: `https://arbitrum-mainnet.infura.io/v3/${process.env.INFURA}`,
-};
-
 export const MULTIADDR: { [chainId: number]: string } = {
     1: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
     3: '0x53c43764255c17bd724f74c4ef150724ac50a3ed',
@@ -62,6 +18,55 @@ export const MULTIADDR: { [chainId: number]: string } = {
     137: '0xa1B2b503959aedD81512C37e9dce48164ec6a94d',
     42161: '0x269ff446d9892c9e19082564df3f5e8741e190a1',
     99: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
+};
+
+export const SOR_CONFIG: Record<Network, SorConfig> = {
+    [Network.MAINNET]: {
+        chainId: Network.MAINNET, //1
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+        wETHwstETH: {
+            id: '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080',
+            address: '0x32296969ef14eb0c6d29669c550d4a0449130230',
+        },
+        multicall: MULTIADDR[Network.MAINNET],
+    },
+    [Network.KOVAN]: {
+        chainId: Network.KOVAN, //42
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+        staBal3Pool: {
+            id: '0x8fd162f338b770f7e879030830cde9173367f3010000000000000000000004d8',
+            address: '0x8fd162f338b770f7e879030830cde9173367f301',
+        },
+        multicall: MULTIADDR[Network.KOVAN],
+    },
+    [Network.GOERLI]: {
+        chainId: Network.GOERLI, //5
+        vault: '0x65748E8287Ce4B9E6D83EE853431958851550311',
+        weth: '0x9A1000D492d40bfccbc03f413A48F5B6516Ec0Fd',
+        multicall: MULTIADDR[Network.GOERLI],
+    },
+    [Network.POLYGON]: {
+        chainId: Network.POLYGON, //137
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+        multicall: MULTIADDR[Network.POLYGON],
+    },
+    [Network.ARBITRUM]: {
+        chainId: Network.ARBITRUM, //42161
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+        multicall: MULTIADDR[Network.ARBITRUM],
+    },
+};
+
+export const PROVIDER_URLS = {
+    [Network.MAINNET]: `https://mainnet.infura.io/v3/${process.env.INFURA}`,
+    [Network.GOERLI]: `https://goerli.infura.io/v3/${process.env.INFURA}`,
+    [Network.KOVAN]: `https://kovan.infura.io/v3/${process.env.INFURA}`,
+    [Network.POLYGON]: `https://polygon-mainnet.infura.io/v3/${process.env.INFURA}`,
+    [Network.ARBITRUM]: `https://arbitrum-mainnet.infura.io/v3/${process.env.INFURA}`,
 };
 
 export const SUBGRAPH_URLS = {
@@ -188,6 +193,11 @@ export const ADDRESSES = {
             address: '0x2f4eb100552ef93840d5adc30560e5513dfffacb',
             decimals: 18,
             symbol: 'bbaUSDT',
+        },
+        COMP: {
+            address: '0xc00e94cb662c3520282e6f5717214004a7f26888',
+            decimals: 18,
+            symbol: 'COMP',
         },
     },
     [Network.KOVAN]: {


### PR DESCRIPTION
Minimal proof of concept that uses a simplified strategy for finding the best paths.

- Considers only the two most liquid paths returned by the route proposer
- Constructs a multicall to queryBatchSwap with sampling queries of 100%, 75/25, 50/50, 25/75.
- Selects the best fee-adjusted outcome across the two paths.

Key benefits to this approach:

- Replaces a significant amount of complexity involved in finding the optimal split across N paths.
- Leverages queryBatchSwap for exact path estimations, meaning the `getOnChainBalances` needs for the SOR would be greatly reduced.

Open questions:

- Does the simplified strategy produce "good enough" outcomes in most situations.
- Does the queryBatchSwap multicall request resolve in a reasonable amount of time? Would a helper contract improve request performance? 
- As is, this strategy would not support routing through weighted pools. We would need to extend the approach if this functionality is critical.
- What is the best strategy to implement `marketSp` (market price after swap). I see a few possible strategies here, but wanted to open it to a discussion.