### PR TITLE
[DRAFT] New RouteProposal implementation - Directed graph for all paths (boosted/non-boosted/mixed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/plugin-typescript": "^8.2.5",
         "@types/chai": "^4.2.10",
+        "@types/graphlib": "^2.1.8",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/mocha": "^7.0.2",
         "@types/node": "^14.0.20",
@@ -68,6 +69,7 @@
         "typescript": "^4.3.5"
     },
     "dependencies": {
+        "graphlib": "^2.1.8",
         "isomorphic-fetch": "^2.2.1"
     },
     "peerDependencies": {

--- a/src/pathGraph/pathGraph.ts
+++ b/src/pathGraph/pathGraph.ts
@@ -1,0 +1,433 @@
+import { NewPath, PoolBase, PoolTypes } from '../types';
+import { keyBy, orderBy, sortBy, uniq } from 'lodash';
+import { Graph } from 'graphlib';
+import { Zero } from '@ethersproject/constants';
+import {
+    PathGraphEdge,
+    PathGraphEdgeLabel,
+    PathGraphTraversalConfig,
+    PoolAddressDictionary,
+    PoolPairMap,
+} from './pathGraphTypes';
+import * as console from 'console';
+
+export class PathGraph {
+    private graph: Graph = new Graph({ multigraph: true });
+    private poolAddressMap: PoolAddressDictionary = {};
+    private graphIsInitialized = false;
+    private maxPathsPerTokenPair = 2;
+
+    public get isGraphInitialized(): boolean {
+        return this.graphIsInitialized;
+    }
+
+    public buildGraph({
+        pools,
+        maxPathsPerTokenPair = 2,
+    }: {
+        pools: PoolBase[];
+        maxPathsPerTokenPair?: number;
+    }): void {
+        this.poolAddressMap = keyBy(pools, 'address');
+        const graph = new Graph({ multigraph: true });
+        const poolPairMap = this.buildSortedPoolPairMap(pools);
+
+        for (const id of Object.keys(poolPairMap)) {
+            const items = poolPairMap[id];
+
+            for (let i = 0; i < items.length; i++) {
+                const poolPair = items[i].poolPair;
+                const pool = this.poolAddressMap[poolPair.address];
+
+                // we take the first `maxPathsPerTokenPair` most liquid pairs.
+                // Always include pairs where the pool has phantom bpt
+                if (
+                    i < maxPathsPerTokenPair ||
+                    pool.tokensList.includes(poolPair.address)
+                ) {
+                    this.addGraphEdgeForPoolPair({
+                        tokenIn: poolPair.tokenIn,
+                        tokenOut: poolPair.tokenOut,
+                        pool,
+                        graph,
+                    });
+                }
+            }
+        }
+
+        this.graph = graph;
+        this.graphIsInitialized = true;
+        this.maxPathsPerTokenPair = maxPathsPerTokenPair;
+    }
+
+    public traverseGraphAndFindBestPaths({
+        tokenIn,
+        tokenOut,
+        config = {
+            maxDepth: 7,
+            maxNonBoostedPathDepth: 2,
+            maxNonBoostedSegmentsInBoostedPath: 1,
+            approxPathsToReturn: 20,
+        },
+    }: {
+        tokenIn: string;
+        tokenOut: string;
+        config?: PathGraphTraversalConfig;
+    }): NewPath[] {
+        const paths: PathGraphEdge[][] = [];
+        const selectedPathIds: string[] = [];
+        let seenPoolAddresses: string[] = [];
+
+        while (paths.length < config.approxPathsToReturn) {
+            //the tokenPairIndex refers to the nth most liquid path for a token
+            //pair x -> y. maxPathsPerTokenPair is provided as a config on graph init
+            for (let idx = 0; idx < this.maxPathsPerTokenPair; idx++) {
+                let foundPath = true;
+
+                //loop until we've found all unique paths from tokenIn -> tokenOut
+                //that meet validity and config criteria, preferring the ${idx}th most
+                //liquid pair. When there is less than ${idx+1} pairs, we default to the
+                //most liquid pair
+                while (foundPath) {
+                    foundPath = false;
+                    const path = this.traverseGraphAndFindUniquePath({
+                        token: tokenIn,
+                        tokenOut,
+                        tokenPairIndex: idx,
+                        config,
+                        tokenPath: [tokenIn],
+                        seenPoolAddresses,
+                        selectedPathIds,
+                    });
+
+                    if (path) {
+                        seenPoolAddresses = [
+                            ...seenPoolAddresses,
+                            ...path.map((segment) => segment.poolAddress),
+                        ];
+
+                        paths.push(path);
+                        selectedPathIds.push(this.getIdForPath(path));
+                        foundPath = true;
+                    }
+                }
+            }
+
+            // the assumption we make here is that if we are going to re-use a pool,
+            // the outcome will most likely be better if we reuse stable pools over
+            // volatile pools. If there are stable pools in the seen list, we remove
+            // them and rerun the traversal.
+            if (
+                paths.length < config.approxPathsToReturn &&
+                seenPoolAddresses.length > 0
+            ) {
+                const volatilePoolAddresses =
+                    this.filterVolatilePools(seenPoolAddresses);
+
+                if (volatilePoolAddresses.length < seenPoolAddresses.length) {
+                    seenPoolAddresses = volatilePoolAddresses;
+                } else {
+                    seenPoolAddresses = [];
+                }
+            } else {
+                // we have either found enough paths, or found no new paths for
+                // for an entire iteration
+                break;
+            }
+        }
+
+        console.log(
+            'abc',
+            paths.map((segment) => segment.map((a) => a.poolId))
+        );
+
+        return paths.map((path) => {
+            return {
+                id: path.map((segment) => segment.poolId).join('_'),
+                swaps: path.map((segment) => ({
+                    pool: segment.poolId,
+                    tokenIn: segment.tokenIn,
+                    tokenOut: segment.tokenOut,
+                    tokenInDecimals: 0,
+                    tokenOutDecimals: 0,
+                })),
+                poolPairData: path.map((segment) => segment.poolPair),
+                pools: path.map(
+                    (segment) => this.poolAddressMap[segment.poolAddress]
+                ),
+                limitAmount: Zero,
+            };
+        });
+    }
+
+    private buildSortedPoolPairMap(pools: PoolBase[]): PoolPairMap {
+        const poolPairMap: PoolPairMap = {};
+
+        for (const pool of pools) {
+            for (let i = 0; i < pool.tokensList.length - 1; i++) {
+                for (let j = i + 1; j < pool.tokensList.length; j++) {
+                    const id = `${pool.tokensList[i]}-${pool.tokensList[j]}`;
+                    const reverseId = `${pool.tokensList[j]}-${pool.tokensList[i]}`;
+
+                    if (!poolPairMap[id]) {
+                        poolPairMap[id] = [];
+                    }
+
+                    if (!poolPairMap[reverseId]) {
+                        poolPairMap[reverseId] = [];
+                    }
+
+                    const poolPair = pool.parsePoolPairData(
+                        pool.tokensList[i],
+                        pool.tokensList[j]
+                    );
+
+                    poolPairMap[id].push({
+                        poolPair,
+                        normalizedLiquidity:
+                            pool.getNormalizedLiquidity(poolPair),
+                    });
+
+                    const poolPairReverse = pool.parsePoolPairData(
+                        pool.tokensList[j],
+                        pool.tokensList[i]
+                    );
+
+                    poolPairMap[reverseId].push({
+                        poolPair: poolPairReverse,
+                        normalizedLiquidity:
+                            pool.getNormalizedLiquidity(poolPairReverse),
+                    });
+                }
+            }
+        }
+
+        for (const id of Object.keys(poolPairMap)) {
+            poolPairMap[id] = orderBy(
+                poolPairMap[id],
+                (item) => item.normalizedLiquidity.toNumber(),
+                'desc'
+            );
+        }
+
+        return poolPairMap;
+    }
+
+    private addGraphEdgeForPoolPair({
+        tokenIn,
+        tokenOut,
+        pool,
+        graph,
+    }: {
+        tokenIn: string;
+        tokenOut: string;
+        pool: PoolBase;
+        graph: Graph;
+    }) {
+        const poolPair = pool.parsePoolPairData(tokenIn, tokenOut);
+
+        const label: PathGraphEdgeLabel = {
+            poolId: pool.id,
+            poolAddress: pool.address,
+            poolPair,
+            normalizedLiquidity: pool.getNormalizedLiquidity(poolPair),
+            isPhantomBptHop:
+                !!this.poolAddressMap[tokenIn] ||
+                !!this.poolAddressMap[tokenOut],
+        };
+
+        graph.setEdge(
+            {
+                name: `${pool.id}-${tokenIn}-${tokenOut}`,
+                v: tokenIn,
+                w: tokenOut,
+            },
+            label
+        );
+    }
+
+    private traverseGraphAndFindUniquePath({
+        token,
+        tokenOut,
+        tokenPath,
+        tokenPairIndex,
+        config,
+        seenPoolAddresses,
+        selectedPathIds,
+    }: {
+        token: string;
+        tokenOut: string;
+        tokenPath: string[];
+        tokenPairIndex: number;
+        config: PathGraphTraversalConfig;
+        seenPoolAddresses: string[];
+        selectedPathIds: string[];
+    }): null | PathGraphEdge[] {
+        const successors = (this.graph.successors(token) || []).filter(
+            (successor) => !tokenPath.includes(successor)
+        );
+
+        if (successors.includes(tokenOut)) {
+            const path = this.buildPath({
+                tokenPath: [...tokenPath, tokenOut],
+                tokenPairIndex,
+            });
+
+            if (
+                path &&
+                this.isValidPath({
+                    path,
+                    config,
+                    seenPoolAddresses,
+                    selectedPathIds,
+                })
+            ) {
+                return path;
+            }
+        }
+
+        // we peek ahead one level, and optimistically sort the successors
+        const sorted = sortBy(successors, (successor) => {
+            const children = this.graph.successors(successor) || [];
+            return children.includes(tokenOut) ? -1 : 1;
+        });
+
+        for (const successor of sorted) {
+            const result = this.traverseGraphAndFindUniquePath({
+                token: successor,
+                tokenOut,
+                tokenPath: [...tokenPath, successor],
+                tokenPairIndex,
+                config,
+                seenPoolAddresses,
+                selectedPathIds,
+            });
+
+            if (result != null) {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
+    private buildPath({
+        tokenPath,
+        tokenPairIndex,
+    }: {
+        tokenPath: string[];
+        tokenPairIndex: number;
+    }): PathGraphEdge[] | null {
+        const path: PathGraphEdge[] = [];
+        let isUnique = false;
+
+        for (let i = 0; i < tokenPath.length - 1; i++) {
+            const outEdges =
+                this.graph.outEdges(tokenPath[i], tokenPath[i + 1]) || [];
+
+            if (outEdges.length > tokenPairIndex) {
+                //if no part of this path uses the current tokenPairIndex, it
+                //will be a duplicate path, so we ignore it.
+                isUnique = true;
+            }
+
+            //this edge has already been qualified in the traversal, so it's safe
+            //to assume its here
+            const edge = outEdges[tokenPairIndex] || outEdges[0];
+            const edgeLabel: PathGraphEdgeLabel = this.graph.edge(edge);
+
+            path.push({
+                tokenIn: tokenPath[i],
+                tokenOut: tokenPath[i + 1],
+                ...edgeLabel,
+            });
+        }
+
+        return isUnique ? path : null;
+    }
+
+    private isValidPath({
+        path,
+        config,
+        seenPoolAddresses,
+        selectedPathIds,
+    }: {
+        path: PathGraphEdge[];
+        config: PathGraphTraversalConfig;
+        seenPoolAddresses: string[];
+        selectedPathIds: string[];
+    }) {
+        const { maxNonBoostedSegmentsInBoostedPath, maxNonBoostedPathDepth } =
+            config;
+        const uniquePools = uniq(path.map((edge) => edge.poolId));
+        const numBoostedSegments = path.filter(
+            (edge) => edge.isPhantomBptHop
+        ).length;
+        const numNonBoostedSegments = path.length - numBoostedSegments;
+        const isBoostedPath = numBoostedSegments > 0;
+
+        //dont include any path that hops through the same pool twice
+        if (uniquePools.length !== path.length) {
+            return false;
+        }
+
+        //non boosted path is too long
+        if (!isBoostedPath && path.length > maxNonBoostedPathDepth) {
+            return false;
+        }
+
+        //boosted path has more non boosted segments than is allowed
+        if (
+            isBoostedPath &&
+            numNonBoostedSegments > maxNonBoostedSegmentsInBoostedPath
+        ) {
+            return false;
+        }
+
+        const intersection = path.filter((segment) =>
+            seenPoolAddresses.includes(segment.poolAddress)
+        );
+
+        //this path contains a pool that has already been used
+        if (intersection.length > 0) {
+            return false;
+        }
+
+        //this is a duplicate path
+        if (selectedPathIds.includes(this.getIdForPath(path))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private getIdForPath(path: PathGraphEdge[]): string {
+        return path
+            .map(
+                (segment) =>
+                    `${segment.poolId}-${segment.tokenIn}-${segment.tokenOut}`
+            )
+            .join('_');
+    }
+
+    private filterVolatilePools(poolAddresses: string[]): string[] {
+        return poolAddresses.filter(
+            (address) =>
+                this.poolAddressMap[address].poolType === PoolTypes.Weighted
+        );
+    }
+
+    //TODO: just for testing
+    private getTokenSymbol(tokenAddress: string): string {
+        const allTokens = Object.values(this.poolAddressMap)
+            .map((pool) => pool.tokens)
+            .flat();
+
+        const token = allTokens.find(
+            (token) =>
+                token.address.toLowerCase() === tokenAddress.toLowerCase()
+        );
+
+        return (token as unknown as { symbol: string })?.symbol || '';
+    }
+}

--- a/src/pathGraph/pathGraph.ts
+++ b/src/pathGraph/pathGraph.ts
@@ -152,7 +152,10 @@ export class PathGraph {
                 const volatilePoolAddresses =
                     this.filterVolatilePools(seenPoolAddresses);
 
-                if (volatilePoolAddresses.length < seenPoolAddresses.length) {
+                if (
+                    volatilePoolAddresses.length > 0 &&
+                    volatilePoolAddresses.length < seenPoolAddresses.length
+                ) {
                     seenPoolAddresses = volatilePoolAddresses;
                 } else {
                     seenPoolAddresses = [];
@@ -473,6 +476,15 @@ export class PathGraph {
 
         if (
             isBoostedPath &&
+            numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
+        ) {
+            return false;
+        }
+
+        // if the path length is greater than maxNonBoostedPathDepth, then this path
+        // will only be valid if its a boosted path, so it must honor maxNonBoostedHopTokensInBoostedPath
+        if (
+            tokenPath.length > config.maxNonBoostedPathDepth &&
             numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
         ) {
             return false;

--- a/src/pathGraph/pathGraph.ts
+++ b/src/pathGraph/pathGraph.ts
@@ -96,7 +96,7 @@ export class PathGraph {
             maxDepth: 7,
             maxNonBoostedPathDepth: 3,
             maxNonBoostedHopTokensInBoostedPath: 1,
-            approxPathsToReturn: 10,
+            approxPathsToReturn: 5,
             ...pathConfig,
         };
 

--- a/src/pathGraph/pathGraph.ts
+++ b/src/pathGraph/pathGraph.ts
@@ -94,7 +94,7 @@ export class PathGraph {
         // apply defaults, allowing caller override whatever they'd like
         const config: PathGraphTraversalConfig = {
             maxDepth: 7,
-            maxNonBoostedPathDepth: 2,
+            maxNonBoostedPathDepth: 3,
             maxNonBoostedHopTokensInBoostedPath: 1,
             approxPathsToReturn: 10,
             ...pathConfig,

--- a/src/pathGraph/pathGraphTypes.ts
+++ b/src/pathGraph/pathGraphTypes.ts
@@ -28,6 +28,7 @@ export interface PathGraphEdge extends PathGraphEdgeLabel {
 export interface PathGraphTraversalConfig {
     maxDepth: number;
     maxNonBoostedPathDepth: number;
-    maxNonBoostedSegmentsInBoostedPath: number;
+    maxNonBoostedHopTokensInBoostedPath: number;
     approxPathsToReturn: number;
+    poolIdsToInclude?: string[];
 }

--- a/src/pathGraph/pathGraphTypes.ts
+++ b/src/pathGraph/pathGraphTypes.ts
@@ -1,0 +1,33 @@
+import { PoolBase, PoolPairBase } from '../types';
+import { BigNumber as OldBigNumber } from '../utils/bignumber';
+
+export type PoolAddressDictionary = {
+    [address: string]: PoolBase;
+};
+
+export type PoolPairMap = {
+    [tokenInTokenOut: string]: {
+        poolPair: PoolPairBase;
+        normalizedLiquidity: OldBigNumber;
+    }[];
+};
+
+export interface PathGraphEdgeLabel {
+    poolId: string;
+    poolAddress: string;
+    normalizedLiquidity: OldBigNumber;
+    poolPair: PoolPairBase;
+    isPhantomBptHop: boolean;
+}
+
+export interface PathGraphEdge extends PathGraphEdgeLabel {
+    tokenIn: string;
+    tokenOut: string;
+}
+
+export interface PathGraphTraversalConfig {
+    maxDepth: number;
+    maxNonBoostedPathDepth: number;
+    maxNonBoostedSegmentsInBoostedPath: number;
+    approxPathsToReturn: number;
+}

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -13,16 +13,16 @@ import { getLidoStaticSwaps, isLidoStableSwap } from './pools/lido';
 import { isSameAddress } from './utils';
 import { EMPTY_SWAPINFO } from './constants';
 import {
-    SwapInfo,
-    SwapTypes,
     NewPath,
-    PoolFilter,
-    Swap,
-    SubgraphPoolBase,
-    SwapOptions,
-    TokenPriceService,
     PoolDataService,
+    PoolFilter,
     SorConfig,
+    SubgraphPoolBase,
+    Swap,
+    SwapInfo,
+    SwapOptions,
+    SwapTypes,
+    TokenPriceService,
 } from './types';
 import { Zero } from '@ethersproject/constants';
 
@@ -70,7 +70,15 @@ export class SOR {
      * @returns {boolean} True if pools fetched successfully, False if not.
      */
     async fetchPools(): Promise<boolean> {
-        return this.poolCacher.fetchPools();
+        const success = await this.poolCacher.fetchPools();
+
+        if (success) {
+            this.routeProposer.initPathGraphWithPools(
+                this.poolCacher.getPools()
+            );
+        }
+
+        return success;
     }
     /**
 

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -73,9 +73,8 @@ export class SOR {
         const success = await this.poolCacher.fetchPools();
 
         if (success) {
-            this.routeProposer.initPathGraphWithPools(
-                this.poolCacher.getPools()
-            );
+            const pools = this.poolCacher.getPools();
+            this.routeProposer.initPathGraphWithPools(pools);
         }
 
         return success;

--- a/test/candidatePaths.spec.ts
+++ b/test/candidatePaths.spec.ts
@@ -315,8 +315,8 @@ describe('Tests pools filtering and path processing', () => {
             WETH.address,
             USDC.address,
             SwapTypes.SwapExactIn,
-            poolsDict,
-            4
+            poolsDict
+            //4
         );
         assert.equal(paths.length, 34, 'Should have 34 paths');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,6 +1361,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/graphlib@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@types/graphlib/-/graphlib-2.1.8.tgz#9edd607e4b863a33b8b78cb08385c0be6896008a"
+  integrity sha512-8nbbyD3zABRA9ePoBgAl2ym8cIwKQXTfv1gaIRTdY99yEOCaHfmjBeRp+BIemS8NtOqoWK7mfzWxjNrxLK3T5w==
+
 "@types/json-schema@^7.0.7":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -3055,6 +3060,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
+
 graphql-request@^3.4.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.7.0.tgz#c7406e537084f8b9788541e3e6704340ca13055b"
@@ -3778,7 +3790,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.11, lodash@^4.17.14:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This PR is a draft proposal for a new approach for the route proposal process.

Currently boosted path finding is a separate process from standard paths, which provides an efficient solution, but is incomplete when hopping from boosted pools to non-boosted pools.

The implementation presented in this PR introduces a single directed graph for all path finding, and leverages configurable parameters to provide reasonable upper limits to prevent the result set from being unusably large.

We build a directed graph for all pools. Nodes are tokens and edges are triads: [pool.id, tokenIn, tokenOut]. The current criterion for including a pool path into this graph is the following:
- We include every pool with phantom BPTs.
- For any token pair x -> y, we include only the most liquid ${maxPathsPerTokenPair} pool pairs (default 2). Measured by the normalized liquidity of the token pair.

Since the path combinations here can get quite large, we use configurable parameters to enforce upper limits across several dimensions, defined in the pathConfig.
- `maxDepth` - the max depth of the traversal (length of token path), defaults to 7.
- `maxNonBoostedPathDepth` - the max depth for any path that does not contain a phantom bpt.
- `maxNonBoostedHopTokensInBoostedPath` - The max number of non boosted hop tokens allowed in a boosted path.
- `approxPathsToReturn` - search for up to this many paths. Since all paths for a single traversal are added, its possible that the amount returned is larger than this number.
- `poolIdsToInclude` - Only include paths with these poolIds (optional)

Additionally, we impose the following requirements for a path to be considered valid
- It does not visit the same token twice
- It does not use the same pool twice

