### PR TITLE
Add gyro and fx pools exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { SOR } from './wrapper';
 export { BPTForTokensZeroPriceImpact as weightedBPTForTokensZeroPriceImpact } from './frontendHelpers/weightedHelpers';
 export { BPTForTokensZeroPriceImpact as stableBPTForTokensZeroPriceImpact } from './frontendHelpers/stableHelpers';
 export * from './types';
+export { safeParseFixed } from './utils';
 export { formatSequence, getTokenAddressesForSwap } from './formatSwaps';
 export { RouteProposer } from './routeProposal';
 export { parseToPoolsDict } from './routeProposal/filtering';
@@ -12,6 +13,10 @@ export { MetaStablePool } from './pools/metaStablePool/metaStablePool';
 export { PhantomStablePool } from './pools/phantomStablePool/phantomStablePool';
 export { ComposableStablePool } from './pools/composableStable/composableStablePool';
 export { LinearPool } from './pools/linearPool/linearPool';
+export { Gyro2Pool } from './pools/gyro2Pool/gyro2Pool';
+export { Gyro3Pool } from './pools/gyro3Pool/gyro3Pool';
+export { GyroEV2Pool } from './pools/gyroEV2Pool/gyroEV2Pool';
+export { FxPool } from './pools/xaveFxPool/fxPool';
 export { getSpotPriceAfterSwapForPath } from './router/helpersClass';
 export * as WeightedMaths from './pools/weightedPool/weightedMath';
 export * as StableMaths from './pools/stablePool/stableMath';
@@ -19,10 +24,14 @@ export * as StableMathBigInt from './pools/stablePool/stableMathBigInt';
 export * as Gyro2Maths from './pools/gyro2Pool/gyro2Math';
 export * as Gyro3Maths from './pools/gyro3Pool/gyro3Math';
 export * as GyroEMaths from './pools/gyroEPool/gyroEMath/gyroEMath';
+export * as FxMaths from './pools/xaveFxPool/fxPoolMath';
 export {
     balancesFromTokenInOut,
     GyroEParams,
     DerivedGyroEParams,
     Vector2,
 } from './pools/gyroEPool/gyroEMath/gyroEMathHelpers';
+export * as GyroEMathFunctions from './pools/gyroEPool/gyroEMath/gyroEMathFunctions';
+export * as GyroHelpersSignedFixedPoint from './pools/gyroHelpers/gyroSignedFixedPoint';
+export * as GyroHelpers from './pools/gyroHelpers/helpers';
 export * as LinearMaths from './pools/linearPool/linearMath';


### PR DESCRIPTION
While developing a dashboard using balancer-sor as a package I notice some functions missing on the export (gyro and fx pools related).