### PR TITLE
Update test rpcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,50 @@ The example file `swapExample.ts` in: [./testScripts](test/testScripts/), demons
 
 To Run:
 
-Create a .env file in root dir with an RPC URL: `RPC_URL_MAINNET=alchemy/infura`
+Create a .env file in root dir. Depending on network being used add an RPC URL (e.g. Alchemy, Infura), e.g.: `RPC_URL_MAINNET=alchemy/infura`
+
+Supported networks out of box for example are:
+
+```
+RPC_URL_MAINNET
+RPC_URL_POLYGON
+RPC_URL_ARBITRUM
+RPC_URL_GNOSIS
+RPC_URL_ZKEVM
+RPC_URL_GOERLI
+```
 
 Install dependencies: `$ yarn install`
 
 Run example: `$ ts-node ./test/testScripts/swapExample.ts`
+
+## Contributing/Adding New Pools
+
+Running tests locally:
+
+1. Add .env and add following RPC URLs (e.g. Alchemy, Infura)
+
+```
+RPC_URL_MAINNET=
+RPC_URL_POLYGON=
+```
+
+2. Start local forked nodes to test against:
+
+`$ yarn run node`
+
+`$ yarn run node:polygon`
+
+3. Run tests:
+   `$ yarn test`
+
+To run a single test file use `test:only`, e.g.:
+
+`$ yarn test:only test/composableStable.integration.spec.ts`
+
+Adding New Pools:
+
+See info [here](https://www.notion.so/SOR-Adding-New-Pools-fa073ec6fecb4c22b1ba13504b04f5bf?pvs=4)
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The example file `swapExample.ts` in: [./testScripts](test/testScripts/), demons
 
 To Run:
 
-Create a .env file in root dir with your infura provider key: `INFURA=your_key`
+Create a .env file in root dir with an RPC URL: `RPC_URL_MAINNET=alchemy/infura`
 
 Install dependencies: `$ yarn install`
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
         "example": "TS_NODE_PROJECT='tsconfig.testing.json' ts-node",
         "coverage": "nyc report --reporter=text-lcov | coveralls",
         "lint": "eslint ./src ./test --ext .ts --max-warnings 0",
-        "node": "npx hardhat node --tsconfig tsconfig.testing.json --fork $(. ./.env && echo $ALCHEMY_URL)",
-        "node:polygon": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.polygon.ts node --fork $(. ./.env && echo $ALCHEMY_URL_POLYGON) --port 8137"
+        "node": "npx hardhat node --tsconfig tsconfig.testing.json --fork $(. ./.env && echo $RPC_URL_MAINNET)",
+        "node:polygon": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.polygon.ts node --fork $(. ./.env && echo $RPC_URL_POLYGON) --port 8137"
     },
     "husky": {
         "hooks": {

--- a/test/ComposableStable.integration.spec.ts
+++ b/test/ComposableStable.integration.spec.ts
@@ -17,7 +17,7 @@ dotenv.config();
 
 let sor: SOR;
 const networkId = Network.MAINNET;
-const jsonRpcUrl = 'https://mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_MAINNET;
 const rpcUrl = 'http://127.0.0.1:8545';
 const blockNumber = 16990000;
 const provider = new JsonRpcProvider(rpcUrl, networkId);

--- a/test/MetaStable.integration.spec.ts
+++ b/test/MetaStable.integration.spec.ts
@@ -42,7 +42,7 @@ const testPool: SubgraphPoolBase = {
 };
 
 const networkId = Network.MAINNET;
-const jsonRpcUrl = 'https://mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_MAINNET;
 const rpcUrl = 'http://127.0.0.1:8545';
 const blockNumber = 16447247;
 const provider = new JsonRpcProvider(rpcUrl, networkId);

--- a/test/PhantomStable.integration.spec.ts
+++ b/test/PhantomStable.integration.spec.ts
@@ -15,7 +15,7 @@ dotenv.config();
 
 let sor: SOR;
 const networkId = Network.MAINNET;
-const jsonRpcUrl = 'https://mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_MAINNET;
 const rpcUrl = 'http://127.0.0.1:8545';
 const blockNumber = 16447247;
 const provider = new JsonRpcProvider(rpcUrl, networkId);

--- a/test/boostedPaths.spec.ts
+++ b/test/boostedPaths.spec.ts
@@ -606,9 +606,7 @@ export async function checkBestPath(
     const swapAmount = parseFixed(amount.toString(), tokenIn.decimals);
     const costOutputToken = BigNumber.from('0');
     const gasPrice = BigNumber.from(`10000000000`);
-    const provider = new JsonRpcProvider(
-        `https://mainnet.infura.io/v3/${process.env.INFURA}`
-    );
+    const provider = new JsonRpcProvider(``);
     const swapGas = BigNumber.from(`32500`);
     const swapInfo = await getFullSwap(
         cloneDeep(pools),

--- a/test/elementPools.spec.ts
+++ b/test/elementPools.spec.ts
@@ -23,9 +23,7 @@ import { MockPoolDataService } from './lib/mockPoolDataService';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 
 // npx mocha -r ts-node/register test/elementPools.spec.ts
 describe(`Tests for Element Pools.`, () => {

--- a/test/elementTrades.spec.ts
+++ b/test/elementTrades.spec.ts
@@ -23,9 +23,7 @@ import { parseFixed } from '@ethersproject/bignumber';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 
 interface TradeData {
     input: {

--- a/test/fullSwaps.spec.ts
+++ b/test/fullSwaps.spec.ts
@@ -19,9 +19,7 @@ const ANT = '0x960b236a07cf122663c4303350609a66a7b288c0'; // ANT lower case
 const MKR2 = '0xef13C0c8abcaf5767160018d268f9697aE4f5375'.toLowerCase();
 const yUSD = '0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4';
 
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 
 describe('Tests full swaps against known values', () => {
     const gasPrice = parseFixed('30', 9);

--- a/test/gyro2Pool.spec.ts
+++ b/test/gyro2Pool.spec.ts
@@ -159,9 +159,7 @@ describe('Gyro2Pool tests USDC > DAI', () => {
 
                 const gasPrice = parseFixed('30', 9);
                 const maxPools = 4;
-                const provider = new JsonRpcProvider(
-                    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-                );
+                const provider = new JsonRpcProvider(``);
 
                 const sor = new SOR(
                     provider,

--- a/test/gyroEV2.integration.spec.ts
+++ b/test/gyroEV2.integration.spec.ts
@@ -12,7 +12,7 @@ import { setUp } from './testScripts/utils';
 dotenv.config();
 
 const networkId = Network.POLYGON;
-const jsonRpcUrl = 'https://polygon-mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = '';
 const rpcUrl = 'http://127.0.0.1:8137';
 const provider = new JsonRpcProvider(rpcUrl, networkId);
 const blocknumber = 42173266;

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -14,9 +14,7 @@ import { BAL, DAI, GUSD, sorConfigEth, USDC, WETH } from './lib/constants';
 
 const marketSp = '7';
 
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(process.env.RPC_URL_MAINNET);
 
 // TS_NODE_PROJECT='tsconfig.testing.json' npx mocha -r ts-node/register test/helpers.spec.ts
 describe(`Tests for Helpers.`, () => {

--- a/test/lbp.spec.ts
+++ b/test/lbp.spec.ts
@@ -13,9 +13,7 @@ import { MockPoolDataService } from './lib/mockPoolDataService';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 
 // npx mocha -r ts-node/register test/lbp.spec.ts
 describe(`Tests for LBP Pools.`, () => {

--- a/test/lido.spec.ts
+++ b/test/lido.spec.ts
@@ -16,9 +16,7 @@ import { parseFixed } from '@ethersproject/bignumber';
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
 const chainId = 1;
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(process.env.RPC_URL_MAINNET);
 const USDC = Lido.USDC[chainId];
 const DAI = Lido.DAI[chainId];
 const USDT = Lido.USDT[chainId];

--- a/test/linear.spec.ts
+++ b/test/linear.spec.ts
@@ -900,9 +900,7 @@ export async function testFullSwap(
     // const costOutputToken = BigNumber.from('1000000000000000000');
     const costOutputToken = BigNumber.from('0');
     const gasPrice = BigNumber.from(`10000000000`);
-    const provider = new JsonRpcProvider(
-        `https://mainnet.infura.io/v3/${process.env.INFURA}`
-    );
+    const provider = new JsonRpcProvider(``);
     const swapGas = BigNumber.from(`32500`);
 
     const swapInfo = await getFullSwap(

--- a/test/metaStablePools.spec.ts
+++ b/test/metaStablePools.spec.ts
@@ -25,9 +25,7 @@ import { MockPoolDataService } from './lib/mockPoolDataService';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 
 async function getStableComparrison(
     stablePools: SubgraphPoolBase[],

--- a/test/phantomStablePools.spec.ts
+++ b/test/phantomStablePools.spec.ts
@@ -238,9 +238,7 @@ async function testFullSwap(
     // const costOutputToken = BigNumber.from('1000000000000000000');
     const costOutputToken = BigNumber.from('0');
     const gasPrice = BigNumber.from(`10000000000`);
-    const provider = new JsonRpcProvider(
-        `https://kovan.infura.io/v3/${process.env.INFURA}`
-    );
+    const provider = new JsonRpcProvider(``);
     const swapGas = BigNumber.from(`32500`);
 
     const swapInfo = await getFullSwap(

--- a/test/stable.integration.spec.ts
+++ b/test/stable.integration.spec.ts
@@ -50,7 +50,7 @@ const testPool: SubgraphPoolBase = {
 };
 
 const networkId = Network.MAINNET;
-const jsonRpcUrl = 'https://mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_MAINNET;
 const rpcUrl = 'http://127.0.0.1:8545';
 const blockNumber = 16447247;
 const provider = new JsonRpcProvider(rpcUrl, networkId);

--- a/test/stablePools.spec.ts
+++ b/test/stablePools.spec.ts
@@ -32,9 +32,7 @@ const multihopPoolsFromFile: {
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 
 describe(`Tests for Stable Pools.`, () => {
     context('limit amounts', () => {

--- a/test/testScripts/constants.ts
+++ b/test/testScripts/constants.ts
@@ -128,12 +128,12 @@ export const SOR_CONFIG: Record<Network, SorConfig> = {
 };
 
 export const PROVIDER_URLS = {
-    [Network.MAINNET]: `https://mainnet.infura.io/v3/${process.env.INFURA}`,
-    [Network.GOERLI]: `https://goerli.infura.io/v3/${process.env.INFURA}`,
-    [Network.POLYGON]: `https://polygon-mainnet.infura.io/v3/${process.env.INFURA}`,
-    [Network.ARBITRUM]: `https://arbitrum-mainnet.infura.io/v3/${process.env.INFURA}`,
-    [Network.GNOSIS]: `https://poa-xdai.gateway.pokt.network/v1/lb/91bc0e12a76e7a84dd76189d`,
-    [Network.ZKEVM]: `${process.env.RPC_URL_ZKEVM}`,
+    [Network.MAINNET]: process.env.RPC_URL_MAINNET,
+    [Network.GOERLI]: process.env.RPC_URL_GOERLI,
+    [Network.POLYGON]: process.env.RPC_URL_POLYGON,
+    [Network.ARBITRUM]: process.env.RPC_URL_ARBITRUM,
+    [Network.GNOSIS]: process.env.RPC_URL_GNOSIS,
+    [Network.ZKEVM]: process.env.RPC_URL_ZKEVM,
 };
 
 export const MULTIADDR: { [chainId: number]: string } = {

--- a/test/testScripts/swapExample.ts
+++ b/test/testScripts/swapExample.ts
@@ -153,5 +153,5 @@ export async function swap(): Promise<void> {
     }
 }
 
-// $ TS_NODE_PROJECT='tsconfig.testing.json' ts-node ./test/testScripts/swapExample.ts
+// $ TS_NODE_PROJECT='tsconfig.testing.json' npx ts-node ./test/testScripts/swapExample.ts
 swap();

--- a/test/v1-v2-compare-testPools.spec.ts
+++ b/test/v1-v2-compare-testPools.spec.ts
@@ -2,9 +2,7 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 import { loadTestFile } from './lib/testHelpers';
 import { compareTest } from './lib/compareHelper';
 
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 
 // This must be updated with pools of interest (see ./test/testData/testPools)
 const testFiles = [

--- a/test/weighted.integration.spec.ts
+++ b/test/weighted.integration.spec.ts
@@ -51,7 +51,7 @@ const testPool: SubgraphPoolBase = {
 };
 
 const networkId = Network.MAINNET;
-const jsonRpcUrl = 'https://mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_MAINNET;
 const rpcUrl = 'http://127.0.0.1:8545';
 const blockNumber = 16447247;
 const provider = new JsonRpcProvider(rpcUrl, networkId);

--- a/test/weightedPools.spec.ts
+++ b/test/weightedPools.spec.ts
@@ -218,9 +218,7 @@ async function getSwapInfo(
     swapAmount: BigNumber,
     useBpts?: boolean
 ) {
-    const provider = new JsonRpcProvider(
-        `https://mainnet.infura.io/v3/${process.env.INFURA}`
-    );
+    const provider = new JsonRpcProvider(``);
     const maxPools = 4;
     const gasPrice = BigNumber.from('0');
     const sor = new SOR(

--- a/test/wrapper.spec.ts
+++ b/test/wrapper.spec.ts
@@ -21,9 +21,7 @@ const subgraphPoolsSmallWithTrade: {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
 
-const provider = new JsonRpcProvider(
-    `https://mainnet.infura.io/v3/${process.env.INFURA}`
-);
+const provider = new JsonRpcProvider(``);
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
 

--- a/test/xaveFxPool.integration.spec.ts
+++ b/test/xaveFxPool.integration.spec.ts
@@ -13,7 +13,7 @@ dotenv.config();
 
 let sor: SOR;
 const networkId = Network.MAINNET;
-const jsonRpcUrl = 'https://mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_MAINNET;
 const rpcUrl = 'http://127.0.0.1:8545';
 const provider = new JsonRpcProvider(rpcUrl, networkId);
 const blocknumber = 16797531;

--- a/test/xaveFxPool.polygon.integration.spec.ts
+++ b/test/xaveFxPool.polygon.integration.spec.ts
@@ -20,7 +20,7 @@ dotenv.config();
 
 let sor: SOR;
 const networkId = Network.POLYGON;
-const jsonRpcUrl = 'https://polygon-mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_POLYGON;
 const rpcUrl = 'http://127.0.0.1:8137';
 const provider = new JsonRpcProvider(rpcUrl, networkId);
 const blocknumber = 43667355;

--- a/test/xaveFxPool.wStable.integration.spec.ts
+++ b/test/xaveFxPool.wStable.integration.spec.ts
@@ -15,7 +15,7 @@ dotenv.config();
 
 let sor: SOR;
 const networkId = Network.MAINNET;
-const jsonRpcUrl = 'https://mainnet.infura.io/v3/' + process.env.INFURA;
+const jsonRpcUrl = process.env.RPC_URL_MAINNET;
 const rpcUrl = 'http://127.0.0.1:8545';
 const provider = new JsonRpcProvider(rpcUrl, networkId);
 const blocknumber = 17129117;


### PR DESCRIPTION
* Update .env RPC vars to be provider agnostic. Now we use:
   * RPC_URL_MAINNET (required for tests and local node script)
   * RPC_URL_POLYGON (required for tests and local node script)
   * Others can be added to run examples
* A lot of tests referencing infura in provider didn't actually need a valid provider so have been changed to empty string
  