### PR TITLE
Fetch pools historical

### DIFF
--- a/src/poolCacher.ts
+++ b/src/poolCacher.ts
@@ -45,7 +45,7 @@ export class PoolCacher {
      *
      * @param {GraphQLArgs} queryArgs - Optional query arguments to pass to pool data service.
      * @param {number} chunkSize - Optional chunksize arguments to pass to pool data service.
-     * @param {GraphQLArgs} blockNumber - Optional blocknumber to pass to the pool data service.
+     * @param {number} blockNumber - Optional blocknumber to pass to the pool data service.
      * @returns {boolean} True if pools fetched successfully, False if not.
      */
     public async fetchPools(

--- a/src/poolCacher.ts
+++ b/src/poolCacher.ts
@@ -40,20 +40,24 @@ export class PoolCacher {
         return pools;
     }
 
-    /*
+    /**
      * Saves updated pools data to internal cache.
      *
      * @param {GraphQLArgs} queryArgs - Optional query arguments to pass to pool data service.
+     * @param {number} chunkSize - Optional chunksize arguments to pass to pool data service.
+     * @param {GraphQLArgs} blockNumber - Optional blocknumber to pass to the pool data service.
      * @returns {boolean} True if pools fetched successfully, False if not.
      */
     public async fetchPools(
         queryArgs?: GraphQLArgs,
-        chunkSize?: number
+        chunkSize?: number,
+        blockNumber?: number
     ): Promise<boolean> {
         try {
             this.pools = await this.poolDataService.getPools(
                 queryArgs,
-                chunkSize
+                chunkSize,
+                blockNumber
             );
             this._finishedFetching = true;
             return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,7 +278,8 @@ export interface TokenPriceService {
 export interface PoolDataService {
     getPools(
         query?: GraphQLArgs,
-        chunkSize?: number
+        chunkSize?: number,
+        blockNumber?: number
     ): Promise<SubgraphPoolBase[]>;
 }
 

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -70,7 +70,7 @@ export class SOR {
      * fetchPools Retrieves pools information and saves to internal pools cache.
      * @param {GraphQLArgs} queryArgs - Optional query arguments to pass to pool data service.
      * @param {number} chunkSize - Optional chunksize arguments to pass to pool data service.
-     * @param {GraphQLArgs} blockNumber - Optional blocknumber to pass to the pool data service.
+     * @param {number} blockNumber - Optional blocknumber to pass to the pool data service.
      * @returns {boolean} True if pools fetched successfully, False if not.
      */
     async fetchPools(

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -68,13 +68,17 @@ export class SOR {
 
     /**
      * fetchPools Retrieves pools information and saves to internal pools cache.
+     * @param {GraphQLArgs} queryArgs - Optional query arguments to pass to pool data service.
+     * @param {number} chunkSize - Optional chunksize arguments to pass to pool data service.
+     * @param {GraphQLArgs} blockNumber - Optional blocknumber to pass to the pool data service.
      * @returns {boolean} True if pools fetched successfully, False if not.
      */
     async fetchPools(
         queryArgs?: GraphQLArgs,
-        chunkSize?: number
+        chunkSize?: number,
+        blockNumber?: number
     ): Promise<boolean> {
-        return this.poolCacher.fetchPools(queryArgs, chunkSize);
+        return this.poolCacher.fetchPools(queryArgs, chunkSize, blockNumber);
     }
 
     /**

--- a/test/lib/onchainData.ts
+++ b/test/lib/onchainData.ts
@@ -21,7 +21,8 @@ export async function getOnChainBalances(
     subgraphPoolsOriginal: SubgraphPoolBase[],
     multiAddress: string,
     vaultAddress: string,
-    provider: Provider
+    provider: Provider,
+    blockNumber?: number
 ): Promise<SubgraphPoolBase[]> {
     if (subgraphPoolsOriginal.length === 0) return subgraphPoolsOriginal;
 
@@ -43,7 +44,13 @@ export async function getOnChainBalances(
             )
         );
 
-    const multiPool = new Multicaller(multiAddress, provider, abis);
+    // if blockNumber given in parameters, construct the multicaller with the blockTag option
+    // this require an archive node
+    const multiPool = blockNumber
+        ? new Multicaller(multiAddress, provider, abis, {
+              blockTag: blockNumber,
+          })
+        : new Multicaller(multiAddress, provider, abis);
 
     const supportedPoolTypes: string[] = Object.values(PoolFilter);
     const subgraphPools: SubgraphPoolBase[] = [];

--- a/test/lib/subgraphPoolDataService.ts
+++ b/test/lib/subgraphPoolDataService.ts
@@ -140,7 +140,6 @@ export class SubgraphPoolDataService implements PoolDataService {
             subgraphUrl: string;
             provider: Provider;
             onchain: boolean;
-            targetBlock?: number;
         }
     ) {}
 

--- a/test/testScripts/swapHistoricalExample.ts
+++ b/test/testScripts/swapHistoricalExample.ts
@@ -108,5 +108,5 @@ export async function swap(): Promise<void> {
     );
 }
 
-// $ TS_NODE_PROJECT='tsconfig.testing.json' npx ts-node ./test/testScripts/swapExample.ts
+// $ TS_NODE_PROJECT='tsconfig.testing.json' npx ts-node ./test/testScripts/swapHistoricalExample.ts
 swap();

--- a/test/testScripts/swapHistoricalExample.ts
+++ b/test/testScripts/swapHistoricalExample.ts
@@ -1,5 +1,4 @@
-// Example using SOR to find the best swap for a given pair and simulate using batchSwap.
-// Requires TRADER_KEY in .env.
+// Example using SOR to find the best swap at a given block and at the most recent block
 // Run using: $ TS_NODE_PROJECT='tsconfig.testing.json' ts-node ./test/testScripts/swapExample.ts
 // NOTE: This is for test/debug purposes, the Balancer SDK Swaps module has a more user friendly interface for interacting with SOR:
 // https://github.com/balancer-labs/balancer-sdk/tree/develop/balancer-js#swaps-module
@@ -7,8 +6,6 @@ import dotenv from 'dotenv';
 dotenv.config();
 import { BigNumber, parseFixed, formatFixed } from '@ethersproject/bignumber';
 import { JsonRpcProvider } from '@ethersproject/providers';
-import { Wallet } from '@ethersproject/wallet';
-import { Contract } from '@ethersproject/contracts';
 import { SOR, SwapInfo, SwapTypes } from '../../src';
 import { CoingeckoTokenPriceService } from '../lib/coingeckoTokenPriceService';
 import { SubgraphPoolDataService } from '../lib/subgraphPoolDataService';
@@ -21,9 +18,6 @@ import {
     vaultAddr,
     MULTIADDR,
 } from './constants';
-import { buildTx, printOutput } from './utils';
-
-import vaultArtifact from '../../src/abi/Vault.json';
 
 // Setup SOR with data services
 function setUp(networkId: Network, provider: JsonRpcProvider): SOR {
@@ -57,10 +51,6 @@ function setUp(networkId: Network, provider: JsonRpcProvider): SOR {
     );
 }
 
-/**
- * This example tries to get the WETH/USDC price at block 17 000 000
- * and compare it to the current price.
- */
 export async function swap(): Promise<void> {
     const networkId = Network.MAINNET;
     const provider = new JsonRpcProvider(PROVIDER_URLS[networkId]);

--- a/test/testScripts/swapHistoricalExample.ts
+++ b/test/testScripts/swapHistoricalExample.ts
@@ -82,7 +82,7 @@ export async function swap(): Promise<void> {
 
     const sorNow = setUp(networkId, provider);
 
-    await sorNow.fetchPools(undefined, undefined, undefined);
+    await sorNow.fetchPools();
 
     // Find swapInfo for best trade for given pair and amount
     const swapInfoNow = await sorNow.getSwaps(

--- a/test/testScripts/swapHistoricalExample.ts
+++ b/test/testScripts/swapHistoricalExample.ts
@@ -1,0 +1,122 @@
+// Example using SOR to find the best swap for a given pair and simulate using batchSwap.
+// Requires TRADER_KEY in .env.
+// Run using: $ TS_NODE_PROJECT='tsconfig.testing.json' ts-node ./test/testScripts/swapExample.ts
+// NOTE: This is for test/debug purposes, the Balancer SDK Swaps module has a more user friendly interface for interacting with SOR:
+// https://github.com/balancer-labs/balancer-sdk/tree/develop/balancer-js#swaps-module
+import dotenv from 'dotenv';
+dotenv.config();
+import { BigNumber, parseFixed, formatFixed } from '@ethersproject/bignumber';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { Wallet } from '@ethersproject/wallet';
+import { Contract } from '@ethersproject/contracts';
+import { SOR, SwapInfo, SwapTypes } from '../../src';
+import { CoingeckoTokenPriceService } from '../lib/coingeckoTokenPriceService';
+import { SubgraphPoolDataService } from '../lib/subgraphPoolDataService';
+import {
+    Network,
+    SOR_CONFIG,
+    ADDRESSES,
+    SUBGRAPH_URLS,
+    PROVIDER_URLS,
+    vaultAddr,
+    MULTIADDR,
+} from './constants';
+import { buildTx, printOutput } from './utils';
+
+import vaultArtifact from '../../src/abi/Vault.json';
+
+// Setup SOR with data services
+function setUp(networkId: Network, provider: JsonRpcProvider): SOR {
+    // The SOR needs to fetch pool data from an external source. This provider fetches from Subgraph and onchain calls.
+    const subgraphPoolDataService = new SubgraphPoolDataService({
+        chainId: networkId,
+        vaultAddress: vaultAddr,
+        multiAddress: MULTIADDR[networkId],
+        provider,
+        subgraphUrl: SUBGRAPH_URLS[networkId],
+        onchain: true,
+    });
+
+    // Use the mock pool data service if you want to use pool data from a file.
+    // const poolsSource = require('../testData/testPools/gusdBug.json');
+    // mockPoolDataService.setPools(poolsSource);
+
+    // Use coingecko to fetch token price information. Used to calculate cost of additonal swaps/hops.
+    const coingeckoTokenPriceService = new CoingeckoTokenPriceService(
+        networkId
+    );
+    // Use the mock token price service if you want to manually set the token price in native asset
+    // import { mockPoolDataService } from '../lib/mockPoolDataService';
+    //  mockTokenPriceService.setTokenPrice('0.001');
+
+    return new SOR(
+        provider,
+        SOR_CONFIG[networkId],
+        subgraphPoolDataService,
+        coingeckoTokenPriceService
+    );
+}
+
+/**
+ * This example tries to get the WETH/USDC price at block 17 000 000
+ * and compare it to the current price.
+ */
+export async function swap(): Promise<void> {
+    const networkId = Network.MAINNET;
+    const provider = new JsonRpcProvider(PROVIDER_URLS[networkId]);
+    // gasPrice is used by SOR as a factor to determine how many pools to swap against.
+    // i.e. higher cost means more costly to trade against lots of different pools.
+    const gasPrice = BigNumber.from('0');
+    // This determines the max no of pools the SOR will use to swap.
+    const maxPools = 4;
+    const tokenIn = ADDRESSES[networkId].WETH;
+    const tokenOut = ADDRESSES[networkId].USDC;
+    const swapType: SwapTypes = SwapTypes.SwapExactIn;
+    const swapAmount = parseFixed('1', 18);
+
+    const sor = setUp(networkId, provider);
+
+    const targetBlockNumber = 17_000_000;
+    // Get pools info using Subgraph/onchain calls
+    await sor.fetchPools(undefined, undefined, targetBlockNumber);
+
+    // Find swapInfo for best trade for given pair and amount
+    const swapInfo: SwapInfo = await sor.getSwaps(
+        tokenIn.address,
+        tokenOut.address,
+        swapType,
+        swapAmount,
+        { gasPrice, maxPools },
+        false
+    );
+
+    const sorNow = setUp(networkId, provider);
+
+    await sorNow.fetchPools(undefined, undefined, undefined);
+
+    // Find swapInfo for best trade for given pair and amount
+    const swapInfoNow = await sorNow.getSwaps(
+        tokenIn.address,
+        tokenOut.address,
+        swapType,
+        swapAmount,
+        { gasPrice, maxPools },
+        false
+    );
+
+    console.log(
+        `1 WETH is ${formatFixed(
+            swapInfoNow.returnAmount,
+            6
+        )} USDC using the most recent data`
+    );
+    console.log(
+        `1 WETH was ${formatFixed(
+            swapInfo.returnAmount,
+            6
+        )} USDC at block ${targetBlockNumber}`
+    );
+}
+
+// $ TS_NODE_PROJECT='tsconfig.testing.json' npx ts-node ./test/testScripts/swapExample.ts
+swap();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4156,9 +4156,9 @@ path-key@^3.0.0, path-key@^3.1.0:
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
-  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
EDIT: I think I found de cleaner way of doing this directly in the SDK: https://github.com/balancer/balancer-sdk/pull/525

Hello Balancer team,

I wondered if I could use your offline SOR/SDK to fetch data about the balancer protocol but historically (like "what was the best price I could get on WETH/USDC at block 17 000 000") and was left without a solution so I tried to add the feature to the SOR.

I don't really understand how to work with the SDK, I have the feeling that the files that need to implements the changes are in the SDK repository (subgraphPoolDataService.ts and onChainData.ts) but because it all starts by creating a SOR object from this repository, I guess the feature must come from here first?

Anyway I added the historical capability here and created a small test file very similar to test\testScripts\swapExample.ts, the new one is: test\testScripts\swapHistoricalExample.ts

To run this test file, you need to set your env variable RPC_URL_MAINNET to an archive node RPC (my infura works well)

The idea in that file is that I first instantiate a sor object using fetchPools like this:
```
const targetBlockNumber = 17_000_000;
await sor.fetchPools(undefined, undefined, targetBlockNumber);
```

and another instance of sor using the basic fetchPool call
`await sorNow.fetchPools();`

and I call the getSwaps() function with both of these sor objects to see the difference, outputing these two lines in the console: 
```
1 WETH is 1664.098257 USDC using the most recent data
1 WETH was 1862.210233 USDC at block 17000000
```

Etherscan gives me 1864 usd per ETH at this block so this looks like a win.

Again, I think this is only the first step, the real implementation will have to be done on the sdk repository. And it would be very much simpler to use the SDK like I do for another project :
```
const balancer = new BalancerSDK({
        network: 100, // gnosis
        rpcUrl: rpcUrl,
    });

const swapsService = balancer.swaps; // Swaps module
await swapsService.fetchPools();
```

(but with the possibility to give the blockNumber to the fetchPools function)

Using the sor directly seems harder as it would mean having to import the SubgraphPoolDataService and getOnChainBalances on my project (at least).

What do you think? Is it a feature that could be usefull and added to the SOR/SDK ?


